### PR TITLE
NEI recipe import support

### DIFF
--- a/bau5/mods/projectbench/nei/NEIProjectBenchConfig.java
+++ b/bau5/mods/projectbench/nei/NEIProjectBenchConfig.java
@@ -1,0 +1,26 @@
+package bau5.mods.projectbench.nei;
+
+import bau5.mods.projectbench.client.ProjectBenchGui;
+import codechicken.nei.api.API;
+import codechicken.nei.api.IConfigureNEI;
+import codechicken.nei.recipe.DefaultOverlayHandler;
+
+public class NEIProjectBenchConfig implements IConfigureNEI {
+	@Override
+	public void loadConfig() {
+
+		API.registerGuiOverlay(ProjectBenchGui.class, "crafting",5,13);
+        API.registerGuiOverlayHandler(ProjectBenchGui.class, new DefaultOverlayHandler(5,13), "crafting");
+	}
+
+	@Override
+	public String getName() {
+		return "Project Bench plugin";
+	}
+
+	@Override
+	public String getVersion() {
+		return "0.1";
+	}
+
+}


### PR DESCRIPTION
Lack of this feature was bugging the hell out of me so I decided to add
it.

Normal left click functionality, showing a shadow recipe on the crafting
grid, works flawlessly.

Shift+left click function, that normally figures the max amount of the
item you can make with your inventory items and pulls all of those item
stacks to the crafting grid, is a bit of an issue. Now it pulls items
only from player inventory and not internal inventory, would need to
implement new overlay handler class to make it do that.
